### PR TITLE
Fix an import in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simplified SPARQL HTTP request client
 
 ```
 var fetch = require('isomorphic-fetch')
-var URL = require('whatwg-url')
+var {URL} = require('whatwg-url')
 var SparqlHttp = require('sparql-http-client')
 
 SparqlHttp.fetch = fetch


### PR DESCRIPTION
Following the doc on the main README it's currently outputting:

`TypeError: this.URL is not a constructor` (`"whatwg-url": "^7.1.0"`)