### PR TITLE
support alternative operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ It comes with a [fetch](https://www.npmjs.com/package/nodeify-fetch) library and
 All methods for SPARQL Queries or SPARQL Updates are attached to the instance property `query`.
 The following query methods are available:
 
-#### query.ask (query, { headers })
+#### query.ask (query, { headers, operation })
 
 Runs an `ASK` query against the given `endpointUrl`.
 It returns async a `boolean` value. 
 
-#### query.construct (query, { headers })
+#### query.construct (query, { headers, operation })
 
 Runs a `CONSTRUCT` or `DESCRIBE` query against the given `endpointUrl`.
 It returns async a stream that emits the result as RDF/JS `Quads`.
 
-#### query.select (query, { headers })
+#### query.select (query, { headers, operation })
 
 Runs a `SELECT` query against the given `endpointUrl`.
 It returns async a stream that emits each row as a single object with the variable as key and the value as RDF/JS `Term` object.
 
-#### query.update (query, { headers })
+#### query.update (query, { headers, operation })
 
 Runs an `INSERT`, `UPDATE` or `DELETE` query against the given `updateUrl`.
 The method is async and doesn't have a return value.
@@ -171,19 +171,19 @@ Runs a query using a direct HTTP POST request against the given `endpointUrl` or
 
 Runs a query using a URL encoded HTTP POST request against the given `endpointUrl` or `updateUrl` if `update` is true.
 
-#### query.ask (query, { headers })
+#### query.ask (query, { headers, operation })
 
 Runs an `ASK` query against the given `endpointUrl`. 
 
-#### query.construct (query, { headers })
+#### query.construct (query, { headers, operation })
 
 Runs a `CONSTRUCT` or `DESCRIBE` query against the given `endpointUrl`.
 
-#### query.select (query, { headers })
+#### query.select (query, { headers, operation })
 
 Runs a `SELECT` query against the given `endpointUrl`.
 
-#### query.update (query, { headers })
+#### query.update (query, { headers, operation })
 
 Runs an `INSERT`, `UPDATE` or `DELETE` query against the given `updateUrl`.
 
@@ -220,6 +220,19 @@ const client = new SparqlClient({
   }
 })
 ```
+
+#### Operation
+
+SPARQL queries and updates over the SPARQL Protocol can be done with different [operations](https://www.w3.org/TR/sparql11-protocol/#protocol).
+By default all read queries use `get` and updates use `postUrlencoded`.
+Very long queries may exceed the maximum request header length.
+For those cases, it's useful to switch to operations that use a `POST` request.
+This can be done by the optional `operation` argument.
+The value must be a string with one of the following values:
+
+- `get`
+- `postUrlencoded`
+- `postDirect`   
 
 #### URL class
 

--- a/RawQuery.js
+++ b/RawQuery.js
@@ -69,44 +69,44 @@ class RawQuery {
     })
   }
 
-  async ask (query, { headers } = {}) {
+  async ask (query, { headers, operation = 'get' } = {}) {
     headers = this.client.mergeHeaders(headers)
 
     if (!headers.has('accept')) {
       headers.set('accept', 'application/sparql-results+json')
     }
 
-    return this.get(query, { headers })
+    return this[operation](query, { headers })
   }
 
-  async construct (query, { headers } = {}) {
+  async construct (query, { headers, operation = 'get' } = {}) {
     headers = new this.client.fetch.Headers(headers)
 
     if (!headers.has('accept')) {
       headers.set('accept', 'application/n-triples')
     }
 
-    return this.get(query, { headers })
+    return this[operation](query, { headers })
   }
 
-  async select (query, { headers } = {}) {
+  async select (query, { headers, operation = 'get' } = {}) {
     headers = this.client.mergeHeaders(headers)
 
     if (!headers.has('accept')) {
       headers.set('accept', 'application/sparql-results+json')
     }
 
-    return this.get(query, { headers })
+    return this[operation](query, { headers })
   }
 
-  async update (query, { headers } = {}) {
+  async update (query, { headers, operation = 'postUrlencoded' } = {}) {
     headers = new this.client.fetch.Headers(headers)
 
     if (!headers.has('accept')) {
       headers.set('accept', '*/*')
     }
 
-    return this.postUrlencoded(query, { headers, update: true })
+    return this[operation](query, { headers, update: true })
   }
 }
 

--- a/StreamQuery.js
+++ b/StreamQuery.js
@@ -8,8 +8,8 @@ class StreamQuery extends RawQuery {
     super({ client })
   }
 
-  async ask (query, { headers } = {}) {
-    const res = await super.ask(query, { headers })
+  async ask (query, { headers, operation } = {}) {
+    const res = await super.ask(query, { headers, operation })
 
     checkResponse(res)
 
@@ -18,8 +18,8 @@ class StreamQuery extends RawQuery {
     return json.boolean
   }
 
-  async construct (query, { headers } = {}) {
-    const res = await super.construct(query, { headers })
+  async construct (query, { headers, operation } = {}) {
+    const res = await super.construct(query, { headers, operation })
 
     checkResponse(res)
 
@@ -28,8 +28,8 @@ class StreamQuery extends RawQuery {
     return parser.import(res.body)
   }
 
-  async select (query, { headers } = {}) {
-    const res = await super.select(query, { headers })
+  async select (query, { headers, operation } = {}) {
+    const res = await super.select(query, { headers, operation })
 
     checkResponse(res)
 
@@ -38,8 +38,8 @@ class StreamQuery extends RawQuery {
     return res.body.pipe(parser)
   }
 
-  async update (query, { headers } = {}) {
-    const res = await super.update(query, { headers })
+  async update (query, { headers, operation } = {}) {
+    const res = await super.update(query, { headers, operation })
 
     checkResponse(res)
   }

--- a/examples/select-raw-post-urlencoded.js
+++ b/examples/select-raw-post-urlencoded.js
@@ -1,0 +1,40 @@
+/*
+
+This example uses the SimpleClient to make a SELECT query using a URL encoded POST request.
+
+*/
+
+const SparqlClient = require('../SimpleClient')
+
+const endpointUrl = 'https://query.wikidata.org/sparql'
+const query = `
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX ps: <http://www.wikidata.org/prop/statement/>
+PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
+
+SELECT ?value WHERE {
+  wd:Q243 p:P2048 ?height.
+
+  ?height pq:P518 wd:Q24192182;
+    ps:P2048 ?value .
+}`
+
+async function main () {
+  const client = new SparqlClient({ endpointUrl })
+  const res = await client.query.select(query, { operation: 'postUrlencoded' })
+
+  if (!res.ok) {
+    return console.error(res.statusText)
+  }
+
+  const content = await res.json()
+
+  for (const row of content.results.bindings) {
+    Object.entries(row).forEach(([key, value]) => {
+      console.log(`${key}: ${value.value} (${value.type})`)
+    })
+  }
+}
+
+main()

--- a/test/RawQuery.test.js
+++ b/test/RawQuery.test.js
@@ -717,6 +717,27 @@ describe('RawQuery', () => {
         strictEqual(header, value)
       })
     })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: true }), async (req, res) => {
+          parameter = req.body.query
+
+          res.end()
+        })
+
+        const endpointUrl = await server.listen()
+
+        const client = new BaseClient({ endpointUrl, fetch })
+        const query = new RawQuery({ client })
+
+        await query.ask(simpleAskQuery, { operation: 'postUrlencoded' })
+
+        strictEqual(parameter, simpleAskQuery)
+      })
+    })
   })
 
   describe('.construct', () => {
@@ -888,6 +909,27 @@ describe('RawQuery', () => {
         strictEqual(header, value)
       })
     })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: true }), async (req, res) => {
+          parameter = req.body.query
+
+          res.end()
+        })
+
+        const endpointUrl = await server.listen()
+
+        const client = new BaseClient({ endpointUrl, fetch })
+        const query = new RawQuery({ client })
+
+        await query.construct(simpleConstructQuery, { operation: 'postUrlencoded' })
+
+        strictEqual(parameter, simpleConstructQuery)
+      })
+    })
   })
 
   describe('.select', () => {
@@ -909,7 +951,7 @@ describe('RawQuery', () => {
         const client = new BaseClient({ endpointUrl, fetch })
         const query = new RawQuery({ client })
 
-        const res = await query.select(simpleConstructQuery)
+        const res = await query.select(simpleSelectQuery)
 
         strictEqual(typeof res, 'object')
         strictEqual(typeof res.text, 'function')
@@ -931,7 +973,7 @@ describe('RawQuery', () => {
         const client = new BaseClient({ endpointUrl, fetch })
         const query = new RawQuery({ client })
 
-        await query.select(simpleConstructQuery)
+        await query.select(simpleSelectQuery)
 
         strictEqual(called, true)
       })
@@ -975,7 +1017,7 @@ describe('RawQuery', () => {
         const client = new BaseClient({ endpointUrl: `${endpointUrl}?${key}=${value}`, fetch })
         const query = new RawQuery({ client })
 
-        await query.select(simpleConstructQuery)
+        await query.select(simpleSelectQuery)
 
         strictEqual(parameters[key], value)
       })
@@ -996,7 +1038,7 @@ describe('RawQuery', () => {
         const client = new BaseClient({ endpointUrl, fetch })
         const query = new RawQuery({ client })
 
-        await query.select(simpleConstructQuery)
+        await query.select(simpleSelectQuery)
 
         strictEqual(accept, 'application/sparql-results+json')
       })
@@ -1018,7 +1060,7 @@ describe('RawQuery', () => {
         const client = new BaseClient({ endpointUrl, fetch })
         const query = new RawQuery({ client })
 
-        await query.select(simpleConstructQuery, {
+        await query.select(simpleSelectQuery, {
           headers: {
             authorization: value
           }
@@ -1050,13 +1092,34 @@ describe('RawQuery', () => {
         })
         const query = new RawQuery({ client })
 
-        await query.select(simpleConstructQuery, {
+        await query.select(simpleSelectQuery, {
           headers: {
             authorization: value
           }
         })
 
         strictEqual(header, value)
+      })
+    })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: true }), async (req, res) => {
+          parameter = req.body.query
+
+          res.end()
+        })
+
+        const endpointUrl = await server.listen()
+
+        const client = new BaseClient({ endpointUrl, fetch })
+        const query = new RawQuery({ client })
+
+        await query.select(simpleSelectQuery, { operation: 'postUrlencoded' })
+
+        strictEqual(parameter, simpleSelectQuery)
       })
     })
   })
@@ -1249,6 +1312,27 @@ describe('RawQuery', () => {
         })
 
         strictEqual(header, value)
+      })
+    })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let content = null
+
+        server.app.post('/', text({ type: '*/*' }), async (req, res) => {
+          content = req.body
+
+          res.end()
+        })
+
+        const endpointUrl = await server.listen()
+
+        const client = new BaseClient({ endpointUrl, fetch })
+        const query = new RawQuery({ client })
+
+        await query.select(simpleUpdateQuery, { operation: 'postDirect' })
+
+        strictEqual(content, simpleUpdateQuery)
       })
     })
   })

--- a/test/StreamQuery.test.js
+++ b/test/StreamQuery.test.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual, strictEqual } = require('assert')
-const { urlencoded } = require('body-parser')
+const { text, urlencoded } = require('body-parser')
 const getStream = require('get-stream')
 const { describe, it } = require('mocha')
 const fetch = require('nodeify-fetch')
@@ -85,6 +85,28 @@ describe('StreamQuery', () => {
         const result = await query.ask(simpleConstructQuery)
 
         strictEqual(result, true)
+      })
+    })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: false }), async (req, res) => {
+          parameter = req.body.query
+
+          res.json({
+            boolean: true
+          })
+        })
+
+        const endpointUrl = await server.listen()
+        const client = new BaseClient({ fetch, endpointUrl })
+        const query = new StreamQuery({ client })
+
+        await query.ask(simpleAskQuery, { operation: 'postUrlencoded' })
+
+        strictEqual(parameter, simpleAskQuery)
       })
     })
   })
@@ -192,6 +214,27 @@ describe('StreamQuery', () => {
           namedNode: true,
           quad: true
         })
+      })
+    })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: false }), async (req, res) => {
+          parameter = req.body.query
+
+          res.status(204).end()
+        })
+
+        const endpointUrl = await server.listen()
+        const client = new BaseClient({ fetch, endpointUrl })
+        const query = new StreamQuery({ client })
+
+        const stream = await query.construct(simpleConstructQuery, { operation: 'postUrlencoded' })
+        await getStream.array(stream)
+
+        strictEqual(parameter, simpleConstructQuery)
       })
     })
   })
@@ -309,6 +352,27 @@ describe('StreamQuery', () => {
         })
       })
     })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let parameter = null
+
+        server.app.post('/', urlencoded({ extended: false }), async (req, res) => {
+          parameter = req.body.query
+
+          res.status(204).end()
+        })
+
+        const endpointUrl = await server.listen()
+        const client = new BaseClient({ fetch, endpointUrl })
+        const query = new StreamQuery({ client })
+
+        const stream = await query.select(simpleSelectQuery, { operation: 'postUrlencoded' })
+        await getStream.array(stream)
+
+        strictEqual(parameter, simpleSelectQuery)
+      })
+    })
   })
 
   describe('.update', () => {
@@ -356,6 +420,26 @@ describe('StreamQuery', () => {
         await query.update(simpleUpdateQuery)
 
         strictEqual(parameter, simpleUpdateQuery)
+      })
+    })
+
+    it('should use the given operation for the request', async () => {
+      await withServer(async server => {
+        let content = null
+
+        server.app.post('/', text({ type: '*/*' }), async (req, res) => {
+          content = req.body
+
+          res.status(204).end()
+        })
+
+        const updateUrl = await server.listen()
+        const client = new BaseClient({ fetch, updateUrl })
+        const query = new StreamQuery({ client })
+
+        await query.update(simpleUpdateQuery, { operation: 'postDirect' })
+
+        strictEqual(content, simpleUpdateQuery)
       })
     })
   })


### PR DESCRIPTION
This PR adds an `operation` argument to the query methods to use alternative operations as defined in the [SPARQL Protocol Spec](https://www.w3.org/TR/sparql11-protocol/#protocol). There are two main use cases for this feature:

- requests optimized for specific stores
- very long queries that may exceed the maximum request header length

This would be a minor version because it adds a new feature, but by default the same operations like before are used.