### PR TITLE
make sure writes to the store are done in the right order

### DIFF
--- a/StreamStore.js
+++ b/StreamStore.js
@@ -128,7 +128,7 @@ class StreamStore {
       url.searchParams.append('graph', graph.value)
     }
 
-    const requestEnd = this.client.fetch(url.toString(), {
+    const requestEnd = this.client.fetch(url, {
       method,
       headers: { 'content-type': 'application/n-triples' },
       body: stream

--- a/StreamStore.js
+++ b/StreamStore.js
@@ -1,6 +1,7 @@
 const { URL } = require('universal-url')
 const { promisify } = require('util')
 const delay = require('promise-the-world/delay')
+const mutex = require('promise-the-world/mutex')
 const TripleToQuadTransform = require('rdf-transform-triple-to-quad')
 const rdf = require('@rdfjs/data-model')
 const N3Parser = require('@rdfjs/parser-n3')
@@ -63,17 +64,22 @@ class StreamStore {
     let request = null
     let last = null
     const all = streamToPromise(stream)
+    const order = mutex()
 
     const read = async () => {
+      await order.lock()
+
       while (true) {
         const quad = stream.read()
 
         if (!quad && all.end) {
           if (request) {
-            return request.stream.push(null)
+            request.stream.push(null)
+
+            break
           }
 
-          return
+          break
         }
 
         if (quad) {
@@ -94,12 +100,14 @@ class StreamStore {
           const triple = rdf.quad(quad.subject, quad.predicate, quad.object)
 
           if (!request.stream.push(quadToNTriples(triple) + '\n')) {
-            return
+            break
           }
         }
 
         await delay(0)
       }
+
+      order.unlock()
     }
 
     read()
@@ -120,7 +128,7 @@ class StreamStore {
       url.searchParams.append('graph', graph.value)
     }
 
-    const requestEnd = this.client.fetch(url, {
+    const requestEnd = this.client.fetch(url.toString(), {
       method,
       headers: { 'content-type': 'application/n-triples' },
       body: stream

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jsonstream2": "^3.0.0",
     "lodash": "^4.17.15",
     "nodeify-fetch": "^2.2.0",
-    "promise-the-world": "^1.0.0",
+    "promise-the-world": "^1.0.1",
     "rdf-transform-triple-to-quad": "^1.0.2",
     "readable-stream": "^3.5.0",
     "universal-url": "^2.0.0"

--- a/test/StreamStore.test.js
+++ b/test/StreamStore.test.js
@@ -344,8 +344,8 @@ describe('StreamStore', () => {
 
         await store.write({ method: 'POST', stream })
 
-        Object.entries(content).forEach(([graphIri, graphContent]) => {
-          strictEqual(graphContent, expected[graphIri])
+        Object.entries(expected).forEach(([graphIri, graphContent]) => {
+          strictEqual(graphContent, content[graphIri])
         })
       })
     })
@@ -686,8 +686,8 @@ describe('StreamStore', () => {
 
         await store.post(stream)
 
-        Object.entries(content).forEach(([graphIri, graphContent]) => {
-          strictEqual(graphContent, expected[graphIri])
+        Object.entries(expected).forEach(([graphIri, graphContent]) => {
+          strictEqual(graphContent, content[graphIri])
         })
       })
     })
@@ -866,8 +866,8 @@ describe('StreamStore', () => {
 
         await store.put(stream)
 
-        Object.entries(content).forEach(([graphIri, graphContent]) => {
-          strictEqual(graphContent, expected[graphIri])
+        Object.entries(expected).forEach(([graphIri, graphContent]) => {
+          strictEqual(graphContent, content[graphIri])
         })
       })
     })


### PR DESCRIPTION
Writing to multiple graphs could have cased an error, cause the `read` function is entered before the last `read` finished and the `last` variable is messed up. This PR makes sure `read` is called in order by adding mutex. The tests have also been fixed. Before a loop over the sent content was done, so missing expected graph data was not detected. Now the loop is done over the expected data.