### PR TITLE
merged client headers also in StreamStore

### DIFF
--- a/StreamStore.js
+++ b/StreamStore.js
@@ -49,7 +49,7 @@ class StreamStore {
 
     return this.client.fetch(url, {
       method,
-      headers: { accept: 'application/n-triples' }
+      headers: this.client.mergeHeaders({ accept: 'application/n-triples' })
     }).then(res => {
       checkResponse(res)
 
@@ -130,7 +130,7 @@ class StreamStore {
 
     const requestEnd = this.client.fetch(url, {
       method,
-      headers: { 'content-type': 'application/n-triples' },
+      headers: this.client.mergeHeaders({ 'content-type': 'application/n-triples' }),
       body: stream
     }).then(res => {
       checkResponse(res)

--- a/test/StreamStore.test.js
+++ b/test/StreamStore.test.js
@@ -194,6 +194,28 @@ describe('StreamStore', () => {
         })
       })
     })
+
+    it('should use the given user and password', async () => {
+      await withServer(async server => {
+        let authorization = null
+        const graph = ns.ex.graph1
+
+        server.app.get('/', async (req, res) => {
+          authorization = req.headers.authorization
+
+          res.status(204).end()
+        })
+
+        const storeUrl = await server.listen()
+        const client = new BaseClient({ fetch, storeUrl, user: 'abc', password: 'def' })
+        const store = new StreamStore({ client })
+
+        const stream = await store.read({ method: 'GET', graph })
+        await getStream.array(stream)
+
+        strictEqual(authorization, 'Basic YWJjOmRlZg==')
+      })
+    })
   })
 
   describe('.write', () => {
@@ -385,6 +407,28 @@ describe('StreamStore', () => {
         }
 
         notStrictEqual(error, null)
+      })
+    })
+
+    it('should use the given user and password', async () => {
+      await withServer(async server => {
+        let authorization = null
+        const quad = rdf.quad(ns.ex.subject1, ns.ex.predicate1, ns.ex.object1, ns.ex.graph1)
+
+        server.app.post('/', async (req, res) => {
+          authorization = req.headers.authorization
+
+          res.status(204).end()
+        })
+
+        const storeUrl = await server.listen()
+        const stream = intoStream.object([quad])
+        const client = new BaseClient({ fetch, storeUrl, user: 'abc', password: 'def' })
+        const store = new StreamStore({ client })
+
+        await store.write({ method: 'POST', stream })
+
+        strictEqual(authorization, 'Basic YWJjOmRlZg==')
       })
     })
   })


### PR DESCRIPTION
The default headers of the client have been ignored in the `StreamStore`. This PR fixes it and adds tests for it.