### PR TITLE
fix: don't emit a chunk if stardog group by bug shows up

### DIFF
--- a/ResultParser.js
+++ b/ResultParser.js
@@ -27,7 +27,7 @@ class ResultParser extends Duplex {
   async _read () {
     const raw = this.jsonParser.read()
 
-    if (!raw) {
+    if (!raw || Object.keys(raw).length === 0) {
       if (!this.writable) {
         return this.push(null)
       }

--- a/test/ResultParser.test.js
+++ b/test/ResultParser.test.js
@@ -34,6 +34,21 @@ describe('ResultParser', () => {
     deepStrictEqual(result, [])
   })
 
+  it('should not emit any chunk when Stardog GROUP BY bug shows up', async () => {
+    const parser = new ResultParser()
+    const content = {
+      results: {
+        bindings: [{}]
+      }
+    }
+
+    parser.end(JSON.stringify(content))
+
+    const result = await getStream.array(parser)
+
+    deepStrictEqual(result, [])
+  })
+
   it('should parse named node values', async () => {
     const parser = new ResultParser()
     const content = {


### PR DESCRIPTION
Stardog returns a JSON like below when a `GROUP BY` is used and there is no result:

```json
{"head":{"vars":["dimension0","dimension1","dimension2"]},"results":{"bindings":[{}]}}
```

This fix ignores empty object results.