### PR TITLE
chore: remove universal-url dependency

### DIFF
--- a/Endpoint.js
+++ b/Endpoint.js
@@ -1,4 +1,3 @@
-const { URL } = require('universal-url')
 const defaultFetch = require('nodeify-fetch')
 
 /**

--- a/README.md
+++ b/README.md
@@ -43,8 +43,3 @@ stream.on('error', err => {
 ```
 
 Find more details on [https://zazuko.github.io/sparql-http-client](https://zazuko.github.io/sparql-http-client)
-
-## URL class
-
-This library uses the URL class of [universal-url](https://www.npmjs.com/package/universal-url).
-Please see [universal-url-lite](https://www.npmjs.com/package/universal-url-lite) for optimized browser builds.

--- a/StreamStore.js
+++ b/StreamStore.js
@@ -1,4 +1,3 @@
-const { URL } = require('universal-url')
 const { promisify } = require('util')
 const TripleToQuadTransform = require('rdf-transform-triple-to-quad')
 const rdf = require('@rdfjs/data-model')

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "promise-the-world": "^1.0.1",
     "rdf-transform-triple-to-quad": "^1.0.2",
     "readable-stream": "^3.5.0",
-    "separate-stream": "^1.0.0",
-    "universal-url": "^2.0.0"
+    "separate-stream": "^1.0.0"
   },
   "devDependencies": {
     "@rdfjs/dataset": "^1.0.1",


### PR DESCRIPTION
This dependency doesn't make sense anymore since this lib doesn't support Node < 8. Applications that need to support really old browsers will be responsible for adding the appropriate polyfill.